### PR TITLE
feat: add phpunit config, autoload-dev, and fix test structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .php-cs-fixer.cache
+.phpunit.result.cache
 vendor
 psalm.xml
 .idea

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
     {
       "name": "jose garcia",
       "email": "jose.garcia051@gmail.com"
+    },
+    {
+      "name": "alejandro foucault",
+      "email": "ale@ajfm88.com"
     }
   ],
   "require": {
@@ -22,13 +26,18 @@
       "src/Garcia/helpers.php"
     ]
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Test\\": "test/"
+    }
+  },
   "require-dev": {
     "phpunit/phpunit": "^9.0",
     "friendsofphp/php-cs-fixer": "^3.65",
     "squizlabs/php_codesniffer": "^3.7"
   },
     "scripts": {
-        "test": "phpunit --bootstrap vendor/autoload.php test/unit/RouterTest.php",
+        "test": "phpunit",
         "fix": "vendor/bin/php-cs-fixer fix ./ --rules=@PSR2",
         "lint": "vendor/bin/phpcs"
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Router Test Suite">
+            <directory>test/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/unit/FakeController.php
+++ b/test/unit/FakeController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Test\Unit;
+
+class FakeController
+{
+    public function index()
+    {
+        return ['Hello' => 'index'];
+    }
+    public function store()
+    {
+        return ['Hello' => 'store'];
+    }
+    public function show()
+    {
+        return ['Hello' => 'show'];
+    }
+    public function update($params)
+    {
+        return ['Hello' => "update" . $params['id']];
+    }
+    public function destroy()
+    {
+        return ['Hello' => 'destroy'];
+    }
+}

--- a/test/unit/RouterTest.php
+++ b/test/unit/RouterTest.php
@@ -5,30 +5,6 @@ namespace Test\Unit;
 use Garcia\Router;
 use PHPUnit\Framework\TestCase;
 
-class FakeController
-{
-    public function index()
-    {
-        return ['Hello' => 'index'];
-    }
-    public function store()
-    {
-        return ['Hello' => 'store'];
-    }
-    public function show()
-    {
-        return ['Hello' => 'show'];
-    }
-    public function update($params)
-    {
-        return ['Hello' => "update" . $params['id']];
-    }
-    public function destroy()
-    {
-        return ['Hello' => 'destroy'];
-    }
-}
-
 class RouterTest extends TestCase
 {
     protected function setUp(): void


### PR DESCRIPTION
  - Add phpunit.xml.dist with test suite pointing to test/ directory
  - Add autoload-dev to composer.json mapping Test\\ namespace to test/
  - Update composer test script to use phpunit directly (no hardcoded path)
  - Extract FakeController into its own file (test/unit/FakeController.php) to comply with PSR-2 one-class-per-file rule
  - Fix CRLF line endings across src/ and test/ files