### PR TITLE
Fix for ticket Router: Header injection in `redirect()`

### DIFF
--- a/src/Garcia/helpers.php
+++ b/src/Garcia/helpers.php
@@ -8,6 +8,14 @@
  */
 function redirect(string $path)
 {
+    if (preg_match('/[\r\n]/', $path)) {
+        throw new \InvalidArgumentException('Invalid redirect path: newline characters are not allowed.');
+    }
+
+    if (!preg_match('/^\/(?!\/)/', $path)) {
+        throw new \InvalidArgumentException('Invalid redirect path: only relative paths starting with / are allowed.');
+    }
+
     header("Location: $path");
     exit;
 }

--- a/test/unit/HelpersTest.php
+++ b/test/unit/HelpersTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Test\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class HelpersTest extends TestCase
+{
+    // --- Header injection ---
+
+    public function testRedirectRejectsCarriageReturnLineFeed(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        redirect("/dashboard\r\nSet-Cookie: malicious=value");
+    }
+
+    public function testRedirectRejectsLineFeed(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        redirect("/dashboard\nSet-Cookie: malicious=value");
+    }
+
+    public function testRedirectRejectsCarriageReturn(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        redirect("/dashboard\rSet-Cookie: malicious=value");
+    }
+
+    // --- Open redirect ---
+
+    public function testRedirectRejectsAbsoluteHttpUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        redirect("http://evil.com/phish");
+    }
+
+    public function testRedirectRejectsAbsoluteHttpsUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        redirect("https://evil.com/phish");
+    }
+
+    public function testRedirectRejectsProtocolRelativeUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        redirect("//evil.com/phish");
+    }
+
+    public function testRedirectRejectsPathWithoutLeadingSlash(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        redirect("dashboard");
+    }
+
+    // --- Valid paths (exceptions must NOT be thrown) ---
+
+    public function testRedirectAcceptsSimpleRelativePath(): void
+    {
+        // Wrap in try/catch to ignore the header()/exit that cannot run in CLI.
+        // The important thing is no InvalidArgumentException is thrown beforehand.
+        try {
+            redirect("/dashboard");
+        } catch (\InvalidArgumentException $e) {
+            $this->fail("redirect() should not reject a valid relative path: " . $e->getMessage());
+        } catch (\Throwable $e) {
+            // header() or exit may throw in test context — that is acceptable.
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRedirectAcceptsRelativePathWithQuery(): void
+    {
+        try {
+            redirect("/search?q=hello&page=2");
+        } catch (\InvalidArgumentException $e) {
+            $this->fail("redirect() should not reject a valid relative path: " . $e->getMessage());
+        } catch (\Throwable $e) {
+            // Acceptable — header/exit side-effects in CLI context.
+        }
+
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
fix: prevent header injection and open redirect in redirect()
- Reject paths containing \r or \n to block header injection
- Restrict to relative paths (must start with /) to block open redirects
- Add HelpersTest.php with 9 unit tests covering injection and redirect cases