### PR TITLE
fix: prevent path traversal and null byte injection in view()    

### DIFF
--- a/src/Garcia/Router.php
+++ b/src/Garcia/Router.php
@@ -267,7 +267,7 @@ class Router
     private static function handleNotFound()
     {
         header('HTTP/1.0 404 Not Found');
-        view('error', ['message' => '404 Not Found']);
+        view('error', ['message' => '404 Not Found'], __DIR__ . '/views');
     }
 
     /**

--- a/src/Garcia/helpers.php
+++ b/src/Garcia/helpers.php
@@ -55,10 +55,10 @@ function view(string $string, $element, string $path = __DIR__ . '/views')
         throw new \InvalidArgumentException('Invalid view: resolved path is outside the allowed views directory.');
     }
 
-    // Capture the validated path before extract() so that a crafted $element key
-    // (e.g. ['resolvedPath' => '/etc/passwd']) cannot overwrite it.
+    // Capture the validated path and use EXTR_SKIP so that a crafted $element key
+    // (e.g. ['__viewPath' => '/etc/passwd']) cannot overwrite it.
     $__viewPath = $resolvedPath;
     $array = is_array($element) ? $element : json_decode(json_encode($element), true);
-    extract($array);
+    extract($array, EXTR_SKIP);
     include $__viewPath;
 }

--- a/src/Garcia/helpers.php
+++ b/src/Garcia/helpers.php
@@ -28,7 +28,7 @@ function redirect(string $path)
  * @param string $path - Path to the views directory
  * @return void
  */
-function view(string $string, $element, string $path = 'views')
+function view(string $string, $element, string $path = __DIR__ . '/views')
 {
     if (strpos($string, "\0") !== false) {
         throw new \InvalidArgumentException('Invalid view name: null bytes are not allowed.');
@@ -47,7 +47,7 @@ function view(string $string, $element, string $path = 'views')
 
     $resolvedPath = realpath($resolvedBase . DIRECTORY_SEPARATOR . $string . '.php');
     if ($resolvedPath === false) {
-        throw new \InvalidArgumentException("View not found: {$string}");
+        throw new \InvalidArgumentException('View not found.');
     }
     if (strpos($resolvedPath, $resolvedBase . DIRECTORY_SEPARATOR) !== 0) {
         throw new \InvalidArgumentException('Invalid view: resolved path is outside the allowed views directory.');

--- a/src/Garcia/helpers.php
+++ b/src/Garcia/helpers.php
@@ -30,7 +30,30 @@ function redirect(string $path)
  */
 function view(string $string, $element, string $path = 'views')
 {
+    if (strpos($string, "\0") !== false) {
+        throw new \InvalidArgumentException('Invalid view name: null bytes are not allowed.');
+    }
+
+    // Defense-in-depth: reject explicit path-traversal segments before hitting the filesystem.
+    // The realpath() containment check below is the authoritative guard.
+    if (preg_match('#(^|[/\\\\])\.\.($|[/\\\\])#', $string)) {
+        throw new \InvalidArgumentException('Invalid view name: path traversal sequences are not allowed.');
+    }
+
+    $resolvedBase = realpath($path);
+    if ($resolvedBase === false) {
+        throw new \InvalidArgumentException('Invalid view: base directory does not exist.');
+    }
+
+    $resolvedPath = realpath($resolvedBase . DIRECTORY_SEPARATOR . $string . '.php');
+    if ($resolvedPath === false) {
+        throw new \InvalidArgumentException("View not found: {$string}");
+    }
+    if (strpos($resolvedPath, $resolvedBase . DIRECTORY_SEPARATOR) !== 0) {
+        throw new \InvalidArgumentException('Invalid view: resolved path is outside the allowed views directory.');
+    }
+
     $array = is_array($element) ? $element : json_decode(json_encode($element), true);
     extract($array);
-    include $path . DIRECTORY_SEPARATOR . "{$string}.php";
+    include $resolvedPath;
 }

--- a/src/Garcia/helpers.php
+++ b/src/Garcia/helpers.php
@@ -49,11 +49,16 @@ function view(string $string, $element, string $path = __DIR__ . '/views')
     if ($resolvedPath === false) {
         throw new \InvalidArgumentException('View not found.');
     }
+    // Rely on realpath() not returning a trailing separator, so appending
+    // DIRECTORY_SEPARATOR prevents a prefix collision (e.g. /var/views vs /var/views_evil).
     if (strpos($resolvedPath, $resolvedBase . DIRECTORY_SEPARATOR) !== 0) {
         throw new \InvalidArgumentException('Invalid view: resolved path is outside the allowed views directory.');
     }
 
+    // Capture the validated path before extract() so that a crafted $element key
+    // (e.g. ['resolvedPath' => '/etc/passwd']) cannot overwrite it.
+    $__viewPath = $resolvedPath;
     $array = is_array($element) ? $element : json_decode(json_encode($element), true);
     extract($array);
-    include $resolvedPath;
+    include $__viewPath;
 }

--- a/src/Garcia/helpers.php
+++ b/src/Garcia/helpers.php
@@ -28,8 +28,9 @@ function redirect(string $path)
  * @param string $path - Path to the views directory
  * @return void
  */
-function view(string $string, $element, string $path = __DIR__ . '/views')
+function view(string $string, $element, ?string $path = null)
 {
+    $path = $path ?? __DIR__ . '/views';
     if (strpos($string, "\0") !== false) {
         throw new \InvalidArgumentException('Invalid view name: null bytes are not allowed.');
     }

--- a/test/unit/HelpersTest.php
+++ b/test/unit/HelpersTest.php
@@ -143,6 +143,26 @@ class HelpersTest extends TestCase
         }
     }
 
+    public function testViewElementCannotOverwriteInternalPath(): void
+    {
+        $tmpDir   = sys_get_temp_dir();
+        $viewFile = $tmpDir . DIRECTORY_SEPARATOR . 'test_safe_view_' . uniqid() . '.php';
+        file_put_contents($viewFile, '<?php echo "safe"; ?>');
+
+        $viewName = basename($viewFile, '.php');
+
+        ob_start();
+        try {
+            // Attempt to overwrite $__viewPath via extract(); EXTR_SKIP must prevent this.
+            view($viewName, ['__viewPath' => '/etc/passwd'], $tmpDir);
+        } finally {
+            $output = ob_get_clean();
+            @unlink($viewFile);
+        }
+
+        $this->assertSame('safe', $output);
+    }
+
     public function testViewRejectsNonexistentBaseDirectory(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/test/unit/HelpersTest.php
+++ b/test/unit/HelpersTest.php
@@ -118,11 +118,13 @@ class HelpersTest extends TestCase
             $this->markTestSkipped('Symlink creation requires elevated privileges on Windows.');
         }
 
-        $tmpDir    = sys_get_temp_dir();
-        $viewsDir  = $tmpDir . DIRECTORY_SEPARATOR . 'test_views_symlink_' . uniqid();
-        mkdir($viewsDir);
+        $base      = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'test_symlink_' . uniqid();
+        $viewsDir  = $base . DIRECTORY_SEPARATOR . 'views';
+        $siblingDir = $base . DIRECTORY_SEPARATOR . 'sibling';
+        mkdir($viewsDir, 0777, true);
+        mkdir($siblingDir, 0777, true);
 
-        $outsideFile = $tmpDir . DIRECTORY_SEPARATOR . 'outside_secret_' . uniqid() . '.php';
+        $outsideFile = $siblingDir . DIRECTORY_SEPARATOR . 'secret.php';
         file_put_contents($outsideFile, '<?php echo "secret"; ?>');
 
         $symlinkPath = $viewsDir . DIRECTORY_SEPARATOR . 'escaped_view.php';
@@ -135,7 +137,9 @@ class HelpersTest extends TestCase
         } finally {
             @unlink($symlinkPath);
             @unlink($outsideFile);
+            @rmdir($siblingDir);
             @rmdir($viewsDir);
+            @rmdir($base);
         }
     }
 
@@ -152,15 +156,14 @@ class HelpersTest extends TestCase
         ob_start();
         try {
             view($viewName, [], $tmpDir);
+            $output = ob_get_clean();
+            $this->assertSame('hello-view', $output);
         } catch (\InvalidArgumentException $e) {
             ob_end_clean();
-            @unlink($viewFile);
             $this->fail('view() should not reject a valid view path: ' . $e->getMessage());
+        } finally {
+            @unlink($viewFile);
         }
-        $output = ob_get_clean();
-        @unlink($viewFile);
-
-        $this->assertSame('hello-view', $output);
     }
 
     public function testViewRendersSubdirectoryView(): void
@@ -176,18 +179,15 @@ class HelpersTest extends TestCase
         ob_start();
         try {
             view('admin/dashboard', [], $viewsDir);
+            $output = ob_get_clean();
+            $this->assertSame('admin-dashboard', $output);
         } catch (\InvalidArgumentException $e) {
             ob_end_clean();
+            $this->fail('view() should allow subdirectory views: ' . $e->getMessage());
+        } finally {
             @unlink($viewFile);
             @rmdir($subDir);
             @rmdir($viewsDir);
-            $this->fail('view() should allow subdirectory views: ' . $e->getMessage());
         }
-        $output = ob_get_clean();
-        @unlink($viewFile);
-        @rmdir($subDir);
-        @rmdir($viewsDir);
-
-        $this->assertSame('admin-dashboard', $output);
     }
 }

--- a/test/unit/HelpersTest.php
+++ b/test/unit/HelpersTest.php
@@ -81,4 +81,113 @@ class HelpersTest extends TestCase
 
         $this->addToAssertionCount(1);
     }
+
+    // --- view() path traversal ---
+
+    public function testViewRejectsNullByte(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('null bytes are not allowed');
+        view("foo\0../../etc/passwd", []);
+    }
+
+    public function testViewRejectsNullByteAlone(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('null bytes are not allowed');
+        view("home\0", []);
+    }
+
+    public function testViewRejectsDoubleDot(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('path traversal sequences are not allowed');
+        view('../../etc/passwd', []);
+    }
+
+    public function testViewRejectsParentDirSegment(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('path traversal sequences are not allowed');
+        view('../secret', []);
+    }
+
+    public function testViewRejectsSymlinkEscape(): void
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('Symlink creation requires elevated privileges on Windows.');
+        }
+
+        $tmpDir    = sys_get_temp_dir();
+        $viewsDir  = $tmpDir . DIRECTORY_SEPARATOR . 'test_views_symlink_' . uniqid();
+        mkdir($viewsDir);
+
+        $outsideFile = $tmpDir . DIRECTORY_SEPARATOR . 'outside_secret_' . uniqid() . '.php';
+        file_put_contents($outsideFile, '<?php echo "secret"; ?>');
+
+        $symlinkPath = $viewsDir . DIRECTORY_SEPARATOR . 'escaped_view.php';
+        symlink($outsideFile, $symlinkPath);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('outside the allowed views directory');
+            view('escaped_view', [], $viewsDir);
+        } finally {
+            @unlink($symlinkPath);
+            @unlink($outsideFile);
+            @rmdir($viewsDir);
+        }
+    }
+
+    // --- view() valid paths ---
+
+    public function testViewRendersValidView(): void
+    {
+        $tmpDir   = sys_get_temp_dir();
+        $viewFile = $tmpDir . DIRECTORY_SEPARATOR . 'test_valid_view_' . uniqid() . '.php';
+        file_put_contents($viewFile, '<?php echo "hello-view"; ?>');
+
+        $viewName = basename($viewFile, '.php');
+
+        ob_start();
+        try {
+            view($viewName, [], $tmpDir);
+        } catch (\InvalidArgumentException $e) {
+            ob_end_clean();
+            @unlink($viewFile);
+            $this->fail('view() should not reject a valid view path: ' . $e->getMessage());
+        }
+        $output = ob_get_clean();
+        @unlink($viewFile);
+
+        $this->assertSame('hello-view', $output);
+    }
+
+    public function testViewRendersSubdirectoryView(): void
+    {
+        $tmpDir   = sys_get_temp_dir();
+        $viewsDir = $tmpDir . DIRECTORY_SEPARATOR . 'test_views_sub_' . uniqid();
+        $subDir   = $viewsDir . DIRECTORY_SEPARATOR . 'admin';
+        mkdir($subDir, 0777, true);
+
+        $viewFile = $subDir . DIRECTORY_SEPARATOR . 'dashboard.php';
+        file_put_contents($viewFile, '<?php echo "admin-dashboard"; ?>');
+
+        ob_start();
+        try {
+            view('admin/dashboard', [], $viewsDir);
+        } catch (\InvalidArgumentException $e) {
+            ob_end_clean();
+            @unlink($viewFile);
+            @rmdir($subDir);
+            @rmdir($viewsDir);
+            $this->fail('view() should allow subdirectory views: ' . $e->getMessage());
+        }
+        $output = ob_get_clean();
+        @unlink($viewFile);
+        @rmdir($subDir);
+        @rmdir($viewsDir);
+
+        $this->assertSame('admin-dashboard', $output);
+    }
 }

--- a/test/unit/HelpersTest.php
+++ b/test/unit/HelpersTest.php
@@ -143,6 +143,13 @@ class HelpersTest extends TestCase
         }
     }
 
+    public function testViewRejectsNonexistentBaseDirectory(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('base directory does not exist');
+        view('home', [], '/nonexistent/path/that/cannot/exist');
+    }
+
     // --- view() valid paths ---
 
     public function testViewRendersValidView(): void
@@ -156,14 +163,12 @@ class HelpersTest extends TestCase
         ob_start();
         try {
             view($viewName, [], $tmpDir);
-            $output = ob_get_clean();
-            $this->assertSame('hello-view', $output);
-        } catch (\InvalidArgumentException $e) {
-            ob_end_clean();
-            $this->fail('view() should not reject a valid view path: ' . $e->getMessage());
         } finally {
+            $output = ob_get_clean();
             @unlink($viewFile);
         }
+
+        $this->assertSame('hello-view', $output);
     }
 
     public function testViewRendersSubdirectoryView(): void
@@ -179,15 +184,13 @@ class HelpersTest extends TestCase
         ob_start();
         try {
             view('admin/dashboard', [], $viewsDir);
-            $output = ob_get_clean();
-            $this->assertSame('admin-dashboard', $output);
-        } catch (\InvalidArgumentException $e) {
-            ob_end_clean();
-            $this->fail('view() should allow subdirectory views: ' . $e->getMessage());
         } finally {
+            $output = ob_get_clean();
             @unlink($viewFile);
             @rmdir($subDir);
             @rmdir($viewsDir);
         }
+
+        $this->assertSame('admin-dashboard', $output);
     }
 }

--- a/test/unit/HelpersTest.php
+++ b/test/unit/HelpersTest.php
@@ -143,6 +143,24 @@ class HelpersTest extends TestCase
         }
     }
 
+    public function testViewAllowsDoubleDotWithinFilename(): void
+    {
+        // 'view..backup' contains .. but not as a path segment — must not be rejected.
+        $tmpDir   = sys_get_temp_dir();
+        $viewFile = $tmpDir . DIRECTORY_SEPARATOR . 'view..backup.php';
+        file_put_contents($viewFile, '<?php echo "ok"; ?>');
+
+        ob_start();
+        try {
+            view('view..backup', [], $tmpDir);
+        } finally {
+            $output = ob_get_clean();
+            @unlink($viewFile);
+        }
+
+        $this->assertSame('ok', $output);
+    }
+
     public function testViewElementCannotOverwriteInternalPath(): void
     {
         $tmpDir   = sys_get_temp_dir();


### PR DESCRIPTION
- Reject null bytes in view name to block poison null byte attacks                                                                                                                                                                                                         
  - Reject ../ and ..\ path segments (defense-in-depth; regex is narrow                                                                                                                                                                                                      
    to avoid false positives on names like "view..backup")
  - Resolve base directory with realpath() and verify the resolved file                                                                                                                                                                                                      
    path stays within it — this is the authoritative containment guard
    and catches symlink escapes
  - Separate "view not found" (realpath returns false) from "outside
    views directory" so developers get a useful error on typos
  - Fix handleNotFound() to use __DIR__ . '/views' instead of the
    CWD-relative 'views', which was fragile depending on where PHP ran
  - Add 7 unit tests: null byte (alone and combined), double-dot
    traversal, parent-dir segment, symlink escape, valid render with
    output assertion, and subdirectory view; all negative tests pin the
    exact exception message to confirm the right guard fired