### PR TITLE
fix: strip query string from URI before route matching

### DIFF
--- a/src/Garcia/Router.php
+++ b/src/Garcia/Router.php
@@ -279,7 +279,7 @@ class Router
     public static function run()
     {
         $method = $_SERVER['REQUEST_METHOD'];
-        $uri = $_SERVER['REQUEST_URI'];
+        $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? '/';
 
         self::handleMiddleware($method, $uri);
 

--- a/test/unit/RouterTest.php
+++ b/test/unit/RouterTest.php
@@ -115,6 +115,34 @@ class RouterTest extends TestCase
         $this->assertSame('{"id":"42"}', $output);
     }
 
+    public function testRunStripsQueryStringForStaticRoute(): void
+    {
+        Router::get('/health', function () {
+            return 'ok';
+        });
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI']    = '/health?foo=bar';
+        ob_start();
+        Router::run();
+        $output = ob_get_clean();
+
+        $this->assertSame('ok', $output);
+    }
+
+    public function testRunStripsQueryStringForDynamicRoute(): void
+    {
+        Router::get('/users/:id', function (array $params) {
+            return json_encode($params);
+        });
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI']    = '/users/42?include=posts';
+        ob_start();
+        Router::run();
+        $output = ob_get_clean();
+
+        $this->assertSame('{"id":"42"}', $output);
+    }
+
     /**
      * @runInSeparateProcess
      */


### PR DESCRIPTION
Use parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) in run() so query strings are removed before handleMiddleware() and handleRequest() receive the URI. Previously any request with query parameters (e.g. /health?foo=bar) would fail to match and return a 404.
Add two tests exercising Router::run() with static and dynamic routes to confirm query strings are stripped correctly.
Fixes: Query string not stripped from URI.