### PR TITLE
fix: stop route matching after first handler is called.

### DIFF
--- a/src/Garcia/Router.php
+++ b/src/Garcia/Router.php
@@ -179,7 +179,7 @@ class Router
                     $params = array_merge($params, $_POST);
                 }
                 self::callHandler($route['handler'], $params);
-                $found = true;
+                return;
             }
         }
 

--- a/test/unit/RouterTest.php
+++ b/test/unit/RouterTest.php
@@ -280,4 +280,28 @@ class RouterTest extends TestCase
 
         $this->assertSame('{"status":"ok"}', $output);
     }
+
+    public function testOnlyFirstMatchingRouteExecutesWhenAnyAndGetOverlap(): void
+    {
+        Router::any('/test', fn () => 'from-any');
+        Router::get('/test', fn () => 'from-get');
+
+        ob_start();
+        Router::handleRequest('GET', '/test');
+        $output = ob_get_clean();
+
+        $this->assertSame('from-any', $output);
+    }
+
+    public function testOnlyFirstMatchingRouteExecutesWithTwoGetRoutes(): void
+    {
+        Router::get('/dup', fn () => 'first');
+        Router::get('/dup', fn () => 'second');
+
+        ob_start();
+        Router::handleRequest('GET', '/dup');
+        $output = ob_get_clean();
+
+        $this->assertSame('first', $output);
+    }
 }


### PR DESCRIPTION
Replace the  flag with an early return so that only the first matching route executes. Previously, duplicate or overlapping routes (e.g. ny + get on the same path) would all fire. Added two tests to cover both the any/get overlap and duplicate get routes.