### PR TITLE
● fix: parse request body based on Content-Type header

### DIFF
--- a/src/Garcia/Router.php
+++ b/src/Garcia/Router.php
@@ -170,13 +170,10 @@ class Router
         foreach (self::$routes as $route) {
             if ($route['method'] === $method && self::matchPath($route['path'], $uri, $params)) {
                 if ($method === 'POST' || $method === 'PUT' || $method === 'PATCH') {
-                    // Capture the POST data
-                    $json = file_get_contents('php://input');
-                    $body = json_decode($json, true);
-                    $array = !empty($body) ? $body : [];
-                    $_REQUEST = [...$_REQUEST, ...$array];
-                    $_POST = $_REQUEST;
-                    $params = array_merge($params, $_POST);
+                    $body = self::parseBody();
+                    $_POST    = array_merge($_POST, $body);
+                    $_REQUEST = array_merge($_REQUEST, $body);
+                    $params   = array_merge($params, $body);
                 }
                 self::callHandler($route['handler'], $params);
                 return;
@@ -218,6 +215,25 @@ class Router
         }
 
         return true;
+    }
+
+    private static function parseBody(): array
+    {
+        $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+
+        if (str_contains($contentType, 'application/json')) {
+            return json_decode(file_get_contents('php://input'), true) ?? [];
+        }
+
+        if (str_contains($contentType, 'application/x-www-form-urlencoded')
+            || str_contains($contentType, 'multipart/form-data')
+        ) {
+            return $_POST;
+        }
+
+        // Unknown/missing Content-Type: try JSON, fall back to $_POST
+        $raw = file_get_contents('php://input');
+        return json_decode($raw, true) ?? $_POST ?? [];
     }
 
     /**

--- a/test/unit/RouterTest.php
+++ b/test/unit/RouterTest.php
@@ -304,4 +304,55 @@ class RouterTest extends TestCase
 
         $this->assertSame('first', $output);
     }
+
+    public function testFormEncodedBodyParsedFromPost(): void
+    {
+        $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+        $_POST = ['name' => 'Alice', 'age' => '30'];
+
+        Router::post('/submit', fn ($params) => "{$params['name']}:{$params['age']}");
+
+        ob_start();
+        Router::handleRequest('POST', '/submit');
+        $output = ob_get_clean();
+
+        $this->assertSame('Alice:30', $output);
+
+        unset($_SERVER['CONTENT_TYPE']);
+        $_POST = [];
+    }
+
+    public function testMultipartFormDataBodyParsedFromPost(): void
+    {
+        $_SERVER['CONTENT_TYPE'] = 'multipart/form-data; boundary=----boundary';
+        $_POST = ['file_name' => 'upload.txt', 'size' => '1024'];
+
+        Router::post('/upload', fn ($params) => "{$params['file_name']}:{$params['size']}");
+
+        ob_start();
+        Router::handleRequest('POST', '/upload');
+        $output = ob_get_clean();
+
+        $this->assertSame('upload.txt:1024', $output);
+
+        unset($_SERVER['CONTENT_TYPE']);
+        $_POST = [];
+    }
+
+    public function testUnknownContentTypeFallsBackToPost(): void
+    {
+        $_SERVER['CONTENT_TYPE'] = 'text/plain';
+        $_POST = ['fallback' => 'yes'];
+
+        Router::post('/fallback', fn ($params) => $params['fallback'] ?? 'missing');
+
+        ob_start();
+        Router::handleRequest('POST', '/fallback');
+        $output = ob_get_clean();
+
+        $this->assertSame('yes', $output);
+
+        unset($_SERVER['CONTENT_TYPE']);
+        $_POST = [];
+    }
 }


### PR DESCRIPTION
POST/PUT/PATCH bodies were always decoded as JSON, silently discarding form-encoded and multipart data. parseBody() now checks Content-Type and delegates to  for form requests. Adds tests for form-encoded, multipart, and unknown content types.