### PR TITLE
test: verify 404 handler resolves view relative to library dir, not CWD

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ This method is used to redirect to another URL. It takes one parameter: the URL 
 ### view
 This method is used to render a view. It takes one parameter: the name of the view to render.
 
+The built-in 404 handler always resolves its error view relative to the library's own directory (`__DIR__ . '/views'`), so it works correctly regardless of the application's current working directory.
+
 > **Security warning:** Never pass raw user input directly as the view name or path. The function enforces the following constraints and throws `\InvalidArgumentException` on violation:
 > - View names containing `../` path traversal sequences are rejected.
 > - Null bytes in the view name are rejected.

--- a/test/unit/RouterTest.php
+++ b/test/unit/RouterTest.php
@@ -155,6 +155,40 @@ class RouterTest extends TestCase
         $this->assertStringContainsString('IMPORTANT:', $output);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testHandleNotFoundRendersFromLibraryDirWhenCwdIsProjectRoot(): void
+    {
+        $originalCwd = getcwd();
+        chdir(dirname(__DIR__, 2));
+
+        ob_start();
+        Router::handleRequest('GET', '/nonexistent');
+        $output = ob_get_clean();
+
+        chdir($originalCwd);
+
+        $this->assertStringContainsString('IMPORTANT:', $output);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testHandleNotFoundRendersFromLibraryDirWhenCwdIsUnrelated(): void
+    {
+        $originalCwd = getcwd();
+        chdir(sys_get_temp_dir());
+
+        ob_start();
+        Router::handleRequest('GET', '/nonexistent');
+        $output = ob_get_clean();
+
+        chdir($originalCwd);
+
+        $this->assertStringContainsString('IMPORTANT:', $output);
+    }
+
     public function testErrorViewEscapesXss(): void
     {
         $message = '<script>alert("xss")</script>';


### PR DESCRIPTION
Add two CWD-scenario tests confirming the built-in 404 handler renders correctly when the working directory is the project root or an unrelated directory (sys_get_temp_dir). Document the __DIR__-based resolution behaviour in the view() README section.