### PR TITLE
test(router): add query-string edge case coverage for route matching

### DIFF
--- a/test/unit/RouterTest.php
+++ b/test/unit/RouterTest.php
@@ -143,6 +143,65 @@ class RouterTest extends TestCase
         $this->assertSame('{"id":"42"}', $output);
     }
 
+    public function testRunMatchesStaticRouteWithTrailingSlashAndQueryString(): void
+    {
+        Router::get('/health', function () {
+            return 'ok';
+        });
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/health/?foo=bar';
+        ob_start();
+        Router::run();
+        $output = ob_get_clean();
+
+        $this->assertSame('ok', $output);
+    }
+
+    public function testRunMatchesDynamicRouteWithTrailingSlashAndQueryString(): void
+    {
+        Router::get('/users/:id', function (array $params) {
+            return json_encode($params);
+        });
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/users/42/?include=posts';
+        ob_start();
+        Router::run();
+        $output = ob_get_clean();
+
+        $this->assertSame('{"id":"42"}', $output);
+    }
+
+    public function testRunTreatsQueryOnlyRequestUriAsRootPath(): void
+    {
+        Router::get('/', function () {
+            return 'root';
+        });
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '?foo=bar';
+        ob_start();
+        Router::run();
+        $output = ob_get_clean();
+
+        $this->assertSame('root', $output);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRunDoesNotMatchDynamicRouteWhenUriContainsEmptySegment(): void
+    {
+        Router::get('/users/:id', function (array $params) {
+            return json_encode($params);
+        });
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/users//42?include=posts';
+        ob_start();
+        Router::run();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('IMPORTANT:', $output);
+    }
+
     /**
      * @runInSeparateProcess
      */


### PR DESCRIPTION
test(router): add query-string edge case coverage for route matching