### PR TITLE
security: add regression tests and docblock for view() variable-overw…

### DIFF
--- a/src/Garcia/helpers.php
+++ b/src/Garcia/helpers.php
@@ -37,6 +37,12 @@ function redirect(string $path): void
  * @param object|array $element - Data to be rendered
  * @param string $path - Path to the views directory
  * @return void
+ *
+ * @security extract() is called with EXTR_SKIP so that keys in $element cannot
+ *           overwrite the already-defined local variables ($string, $path,
+ *           $__viewPath, etc.).  All path-safety checks run before extract(),
+ *           and the validated path is stored in $__viewPath — a name unlikely
+ *           to collide with template data even without EXTR_SKIP.
  */
 function view(string $string, $element, ?string $path = null)
 {

--- a/test/unit/HelpersTest.php
+++ b/test/unit/HelpersTest.php
@@ -177,6 +177,58 @@ class HelpersTest extends TestCase
         $this->assertSame('safe', $output);
     }
 
+    public function testViewElementCannotOverwriteStringParam(): void
+    {
+        $tmpDir    = sys_get_temp_dir();
+        $safeFile  = $tmpDir . DIRECTORY_SEPARATOR . 'test_safe_string_' . uniqid() . '.php';
+        $evilFile  = $tmpDir . DIRECTORY_SEPARATOR . 'test_evil_string_' . uniqid() . '.php';
+        file_put_contents($safeFile, '<?php echo "safe"; ?>');
+        file_put_contents($evilFile, '<?php echo "evil"; ?>');
+
+        $safeName = basename($safeFile, '.php');
+        $evilName = basename($evilFile, '.php');
+
+        ob_start();
+        try {
+            // Attempt to redirect $string to the evil view via extract(); EXTR_SKIP must prevent this.
+            view($safeName, ['string' => $evilName], $tmpDir);
+        } finally {
+            $output = ob_get_clean();
+            @unlink($safeFile);
+            @unlink($evilFile);
+        }
+
+        $this->assertSame('safe', $output);
+    }
+
+    public function testViewElementCannotOverwritePathParam(): void
+    {
+        $base      = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'test_path_overwrite_' . uniqid();
+        $validDir  = $base . DIRECTORY_SEPARATOR . 'views';
+        $evilDir   = $base . DIRECTORY_SEPARATOR . 'evil';
+        mkdir($validDir, 0777, true);
+        mkdir($evilDir, 0777, true);
+
+        $viewName  = 'shared_view';
+        file_put_contents($validDir . DIRECTORY_SEPARATOR . $viewName . '.php', '<?php echo "safe"; ?>');
+        file_put_contents($evilDir  . DIRECTORY_SEPARATOR . $viewName . '.php', '<?php echo "evil"; ?>');
+
+        ob_start();
+        try {
+            // Attempt to redirect $path to the evil directory via extract(); EXTR_SKIP must prevent this.
+            view($viewName, ['path' => $evilDir], $validDir);
+        } finally {
+            $output = ob_get_clean();
+            @unlink($validDir . DIRECTORY_SEPARATOR . $viewName . '.php');
+            @unlink($evilDir  . DIRECTORY_SEPARATOR . $viewName . '.php');
+            @rmdir($validDir);
+            @rmdir($evilDir);
+            @rmdir($base);
+        }
+
+        $this->assertSame('safe', $output);
+    }
+
     public function testViewRejectsNonexistentBaseDirectory(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
…rite protection

Closes the remaining acceptance criteria from the extract() overwrite ticket. The EXTR_SKIP fix was already in place; this commit adds explicit regression coverage and documents why.
- test: assert  param cannot be overwritten via element data
- test: assert  param cannot be redirected to an evil directory
- docs: @security docblock on view() explaining EXTR_SKIP guarantee and the  naming choice